### PR TITLE
ignoreErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ const Attachment = saline.model('Attachment', AttachmentSchema);
 
 ```
 
-## saline.model(modelName, schema)
+## saline.model(modelName, schema, ignoreErrors)
 
 ### Params
 
@@ -210,6 +210,8 @@ const Attachment = saline.model('Attachment', AttachmentSchema);
   used in relationship lookups.
 * `schema` (Schema) - The saline Schema object you wish to be converted into a
   model.
+* `ignoreErrors` (boolean) - When true, ignores any schema errors, failing silently in attempt to update/insert as much 
+  data as possible. Defaults to false.
 
 Returns the new Model. More on models later.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ const Attachment = saline.model('Attachment', AttachmentSchema);
 
 ```
 
-## saline.model(modelName, schema, ignoreErrors)
+## saline.model(modelName, schema, options)
 
 ### Params
 
@@ -210,8 +210,16 @@ const Attachment = saline.model('Attachment', AttachmentSchema);
   used in relationship lookups.
 * `schema` (Schema) - The saline Schema object you wish to be converted into a
   model.
+* `options` (object) - The model configuration options. 
+     
+#### Model Configuration Options
+  ```
+   { 
+     ignoreErrors: false 
+   } ```
+      
 * `ignoreErrors` (boolean) - When true, ignores any schema errors, failing silently in attempt to update/insert as much 
-  data as possible. Defaults to false.
+                    data as possible. Defaults to false.
 
 Returns the new Model. More on models later.
 

--- a/lib/model/model.js
+++ b/lib/model/model.js
@@ -10,6 +10,7 @@ const objectUtils = require('../utils/object-utils');
 const assert = require('../utils/assert');
 const objectMap = objectUtils.objectMap;
 const objectReduce = objectUtils.objectReduce;
+const SalineError = require('../utils/error');
 
 const ID_FIELD = 'Id';
 
@@ -19,19 +20,22 @@ const _refresh = Symbol('refresh');
 const _definitionPromise = Symbol('definitionPromise');
 const _attributes = Symbol('attributes');
 const _transformer = Symbol('transformer');
+const _ignoreErrors = Symbol('ignoreErrors');
 
 // private methods
 const _applyDescribe = Symbol('applyDescribe');
 
 class Model {
 
-  constructor(schema, tenant) {
+  constructor(schema, tenant, ignoreErrors) {
+    ignoreErrors = ignoreErrors || false;
 
     this[_tenant] = tenant;
     this[_refresh] = true;
     this[_definitionPromise] = null;
     this[_attributes] = schema.attributes;
     this[_transformer] = new Transformer(this[_attributes], 'column');
+    this[_ignoreErrors] = ignoreErrors;
 
     Object.defineProperties(this, {
       schema: { value: schema },
@@ -190,6 +194,7 @@ class Model {
     //   I don't think so, but also letting it go through can suggest that
     //   everything worked. Something to think about
     assert(!Array.isArray(obj), 'multiple creates are not supported at this time');
+    let errors = [];
 
     return this.callHook([ 'save', 'create' ], obj, (modifiedObj) => {
       return this.describeSobject()
@@ -201,9 +206,14 @@ class Model {
           assert(describe.creatable, `Unable to create "${describe.label}"`);
 
           obj = objectReduce(describe.fields, (newObj, field, key) => {
-            // TODO keep track of fields that have errors or aren't creatable so
-            // that we can return them in some sort of response
-            if (!field.creatable || field.deprecated || field.error) return newObj;
+            if (!field.creatable || field.deprecated || field.error) {
+              if (!this[_ignoreErrors]) {
+                throw new SalineError(`Unable to create field: ${field.error.message}`);
+              }
+
+              errors.push(field);
+              return newObj;
+            }
 
             newObj[field.column] = objectPath.get(modifiedObj, key, modifiedObj[key] || field.defaultValue);
             return newObj;
@@ -214,7 +224,12 @@ class Model {
         })
         .then((results) => {
           assert(results.success, results.errors);
-          return results.id;
+          return {
+            data: {
+              id: results.id,
+            },
+            errors,
+          };
         });
     }, this);
 
@@ -238,6 +253,10 @@ class Model {
 
           obj = objectReduce(describe.fields, (newObj, field, key) => {
             if (key !== describe.idField && !field.updatable || field.deprecated || field.error) {
+              if (!this[_ignoreErrors]) {
+                throw new SalineError(`Unable to update field: ${field.error.message}`);
+              }
+
               errors.push(field);
               return newObj;
             }
@@ -255,7 +274,12 @@ class Model {
         })
         .then((results) => {
           assert(results.success, results.errors);
-          return { id: results.id, errors };
+          return {
+            data: {
+              id: results.id,
+            },
+            errors,
+          };
         });
     }, this);
   }

--- a/lib/model/model.js
+++ b/lib/model/model.js
@@ -27,15 +27,15 @@ const _applyDescribe = Symbol('applyDescribe');
 
 class Model {
 
-  constructor(schema, tenant, ignoreErrors) {
-    ignoreErrors = ignoreErrors || false;
+  constructor(schema, tenant, options) {
+    options = options || {};
 
     this[_tenant] = tenant;
     this[_refresh] = true;
     this[_definitionPromise] = null;
     this[_attributes] = schema.attributes;
     this[_transformer] = new Transformer(this[_attributes], 'column');
-    this[_ignoreErrors] = ignoreErrors;
+    this[_ignoreErrors] = options.ignoreErrors || false;
 
     Object.defineProperties(this, {
       schema: { value: schema },

--- a/lib/saline.js
+++ b/lib/saline.js
@@ -37,15 +37,14 @@ class Saline {
    * @function Saline#model
    * @param {string} name - The name of the model
    * @param {Schema} schema - The schema to convert into a model
-   * @param {boolean} ignoreErrors - When true, ignores any schema errors, failing silently in attempt to update/insert as much
-   *                                  data as possible. Defaults to false.
+   * @param {object} options - Model configuration options
+   *
    * @returns {Saline} The saline instance
    */
-  model(name, schema, ignoreErrors) {
+  model(name, schema, options) {
     assert(schema instanceof Schema, `Non-Schema passed to saline.model: ${name}`);
-    ignoreErrors = ignoreErrors || false;
 
-    this.models[name] = new Model(schema, this, ignoreErrors);
+    this.models[name] = new Model(schema, this, options);
 
     return this.models[name];
   }

--- a/lib/saline.js
+++ b/lib/saline.js
@@ -37,12 +37,15 @@ class Saline {
    * @function Saline#model
    * @param {string} name - The name of the model
    * @param {Schema} schema - The schema to convert into a model
+   * @param {boolean} ignoreErrors - When true, ignores any schema errors, failing silently in attempt to update/insert as much
+   *                                  data as possible. Defaults to false.
    * @returns {Saline} The saline instance
    */
-  model(name, schema) {
+  model(name, schema, ignoreErrors) {
     assert(schema instanceof Schema, `Non-Schema passed to saline.model: ${name}`);
+    ignoreErrors = ignoreErrors || false;
 
-    this.models[name] = new Model(schema, this);
+    this.models[name] = new Model(schema, this, ignoreErrors);
 
     return this.models[name];
   }


### PR DESCRIPTION
Added ignoreErrors parameter to fail silently when true. When false, it fails early, throwing an error with detail about which field will not update or insert because of permission issues, column not found, etc.

Changed the return values of create and update. They now return an object of the following format:

`
{
  data: {},
  errors: []
}
`